### PR TITLE
Launch Pipeline using gnu parallels: qgc + gstreamer + Window tiling + rov_sensor_broadcaster

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "launch/rov-sensor-broadcaster"]
+	path = launch/rov-sensor-broadcaster
+	url = https://github.com/KelpieRobotics/rov-sensor-broadcaster.git

--- a/launch/launch_all.sh
+++ b/launch/launch_all.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/bash
+
+# sudo apt install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl -y
+# sudo apt install libfuse2 -y
+# sudo apt install libxcb-xinerama0 libxkbcommon-x11-0 libxcb-cursor-dev -y
+# sudo apt-get install libpulse-mainloop-glib0
+
+# sudo usermod -a -G dialout $USER # (one time only)
+# sudo apt-get remove modemmanager -y # (logout and login again to enable the change to user permissions)
+
+# sudo apt install parallel
+# sudo apt-get install xdotool
+# sudo apt-get install gnome-terminal
+
+# clear and define snippets & logs directory
+rm -rf ./snippets/*
+rm -rf ./logs/*
+mkdir -p "./logs"
+mkdir -p "./snippets"
+
+# function to run gnu parallels
+run_pipeline() {
+    case $1 in
+        1)
+          # chmod +x ./QGroundControl.AppImage # uncomment if needed
+          # launch qgroundcontrol (camera 1 preview + logs)
+          ./QGroundControl.AppImage 2>&1 | tee "logs/qgroundcontrol.log" # errors included in logs
+          ;;
+        2)
+          # save snippets from camera 1 + log output (background to free up terminal)
+          gst-launch-1.0 -v udpsrc port=5600 \
+            caps='application/x-rtp,media=video,clock-rate=90000,encoding-name=(string)H264, payload=(int)96, width=(int)160, height=(int)120' \
+            ! rtph264depay ! h264parse ! avdec_h264 \
+            ! queue ! videorate ! video/x-raw,framerate=0.2/1 \
+            ! jpegenc ! multifilesink location="snippets/frame-%05d.jpg" \
+            2>&1 | tee "logs/stream1.log" &
+          ;;
+        3)
+          # preview camera 2 + log output
+          gst-launch-1.0 -v udpsrc port=5601 \
+            caps='application/x-rtp,media=video,clock-rate=90000,encoding-name=(string)H264, payload=(int)96, width=(int)160, height=(int)120' \
+            ! rtph264depay ! h264parse ! avdec_h264 \
+            ! queue ! videoconvert ! autovideosink \
+            2>&1 | tee "logs/stream2.log" &
+          ;;
+        4)
+          # preview camera 3 + log output
+          gst-launch-1.0 -v udpsrc port=5602 \
+            caps='application/x-rtp,media=video,clock-rate=90000,encoding-name=(string)H264, payload=(int)96, width=(int)160, height=(int)120' \
+            ! rtph264depay ! h264parse ! avdec_h264 \
+            ! queue ! videoconvert ! autovideosink \
+            2>&1 | tee "logs/stream3.log" &
+          ;;
+        5)
+          # give time for windows to initialize
+          sleep 10
+
+          # get window IDs
+          QGC_ID=$(xdotool search --name "QGroundControl" | head -n 1)
+          CAM1_ID=$(xdotool search --name "OpenGL" | sed -n '1p')
+          CAM2_ID=$(xdotool search --name "OpenGL" | sed -n '2p')
+
+          # window IDs
+          echo "QGroundControl window ID: $QGC_ID"
+          echo "Camera 1 window ID: $CAM1_ID"
+          echo "Camera 2 window ID: $CAM2_ID"
+
+          # move and resize windows
+          # move QGroundControl to the left
+          xdotool windowmove $QGC_ID 0 0
+          xdotool windowsize $QGC_ID 960 1080
+
+          # move Camera 1 to the top-right
+          xdotool windowmove $CAM1_ID 960 0
+          xdotool windowsize $CAM1_ID 960 540
+
+          # move Camera 2 to the bottom-right
+          xdotool windowmove $CAM2_ID 960 540
+          xdotool windowsize $CAM2_ID 960 540
+          ;;
+        6)
+          SERVER_DIR="./rov-sensor-broadcaster/src"
+
+          # build and run server
+          g++ -o server.o $SERVER_DIR/ds18b20/ds18b20.cpp $SERVER_DIR/sht30/sht30.cpp $SERVER_DIR/server.cpp
+          sudo ./server.o
+          ;;
+    esac
+}
+
+export -f run_pipeline
+
+# run all pipelines in parallel
+parallel -j2 run_pipeline ::: 1 3 6 #5 # choose which pipelines to run

--- a/launch/launch_all.sh
+++ b/launch/launch_all.sh
@@ -18,6 +18,48 @@ rm -rf ./logs/*
 mkdir -p "./logs"
 mkdir -p "./snippets"
 
+# Image stitching
+main_loop() {
+    trap SIGINT
+    sleep 1 # Small time to actually to kill the process
+    # Just Spam CTRL-C 
+
+    trap "capture_images" INT
+    
+    parallel -j2 run_pipeline ::: 1 3 6 #5 # choose which pipelines to run
+
+    trap SIGINT 
+
+    exit
+}
+
+capture_images () {
+    trap SIGINT
+    sleep 1 # Small time to actually to kill the process
+
+    trap "stitch_images" INT
+
+    rm -rf ./source_images ./tmp;
+    mkdir ./source_images ./tmp;
+
+    parallel -j2 run_pipeline ::: 1 3-alt 6 #5 # choose which pipelines to run
+  
+    stitch_images
+}
+
+stitch_images() {
+    trap SIGINT
+    sleep 1 # Small time to actually to kill the process
+    trap "main_loop" INT;
+    python3 ./stitch.py;
+    # python3 ; # main.py should create a subproccess that listens to node and saves to specific folder & also stitches images
+    trap SIGINT;
+    $XPANO;
+    ./main.bash;
+    exit
+}
+
+
 # function to run gnu parallels
 run_pipeline() {
     case $1 in
@@ -36,6 +78,14 @@ run_pipeline() {
             2>&1 | tee "logs/stream1.log" &
           ;;
         3)
+          # preview camera 2 + log output
+          gst-launch-1.0 -v udpsrc port=5601 \
+            caps='application/x-rtp,media=video,clock-rate=90000,encoding-name=(string)H264, payload=(int)96, width=(int)160, height=(int)120' \
+            ! rtph264depay ! h264parse ! avdec_h264 \
+            ! queue ! videoconvert ! autovideosink \
+            2>&1 | tee "logs/stream2.log" &
+          ;;
+        3-alt)
           # preview camera 2 + log output
           gst-launch-1.0 -v udpsrc port=5601 \
             caps='application/x-rtp,media=video,clock-rate=90000,encoding-name=(string)H264, payload=(int)96, width=(int)160, height=(int)120' \
@@ -91,4 +141,6 @@ run_pipeline() {
 export -f run_pipeline
 
 # run all pipelines in parallel
-parallel -j2 run_pipeline ::: 1 3 6 #5 # choose which pipelines to run
+# parallel -j2 run_pipeline ::: 1 3 6 #5 # choose which pipelines to run
+
+main_loop

--- a/launch/stitch.py
+++ b/launch/stitch.py
@@ -1,0 +1,126 @@
+import os
+from typing import List, Tuple, Optional
+import subprocess
+
+from multiprocessing import Process, Pipe
+from multiprocessing.connection import Connection
+
+import uuid
+
+
+def _merge_images(images: List[str], output_name: str, output_conn: Connection, crop: Optional[Tuple[int, int]]):
+    process = subprocess.Popen(
+        ["./xpano/build/xpano", *[f"{name}" for name in images], f"--output={output_name}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1
+    )
+    
+    try:
+        for line in process.stdout:
+            print(line, end="")
+            try:
+                output_conn.send(line)
+            except BrokenPipeError:
+                break
+
+    finally:
+        process.wait()
+        print("Process has terminated.")
+        try:
+            output_conn.send("Process has terminated.\n")
+            output_conn.close()
+        except BrokenPipeError:
+            pass
+    if crop is not None:
+        image = Image.open(f"{output_name}")
+                
+        # Crop the image from the center
+        cropped_image = crop_image(image, *crop)
+        
+        # Save the cropped image
+        cropped_image.save(os.path.join(f"{output_name}"))
+        print(f"Saved cropped image tmp/{output_name}")
+
+
+def merge_images(images: List[str], output_name:str, crop: Optional[Tuple[int, int]]) -> Tuple[Process, Connection]:
+    tx, rx = Pipe()
+
+    process = Process(
+        target=_merge_images,
+        args=(images, output_name, tx, crop)
+    )
+
+    process.start()
+
+    return (process, rx)
+
+def windowed_stiching(directory: str, window_size: int, overlap: int = 1) -> List[str]:
+    files = sorted(
+        [f"./source_images/{f}" for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))],
+        key=lambda x: int(os.path.basename(x).split('.')[0])  # Extract numeric part and sort
+    )
+    new_files=[]
+    while len(files) > 0:
+        processes = []
+        new_files = []
+
+        if len(files) < window_size:
+            file_name= f"./tmp/{uuid.uuid4().hex}.png"
+        
+            processes.append(
+                merge_images(
+                    files,
+                    file_name,
+                    None
+                )
+            )
+        else:
+            for idx in range(len(files) // (window_size - overlap)):
+                file_name= f"./tmp/{uuid.uuid4().hex}.png"
+                
+                new_files.append(file_name)
+                
+                if idx == 0:
+                    window = files[max(idx*window_size, 0):min((idx+1)*window_size, len(files))]
+
+                    if len(window) < 2:
+                        new_files.append(*window)
+                        break
+
+                    print(f"{window} -> {file_name}")
+                    processes.append(
+                        merge_images(
+                            window,
+                            file_name,
+                            None
+                        )
+                    )
+                else:
+                    window = files[max(idx*window_size-overlap*idx, 0):min((idx+1)*window_size-overlap*idx, len(files))]
+                    
+                    if len(window) < 2:
+                        new_files.append(*window)
+                        break
+                    print(f"{window} -> {file_name}")
+
+
+                    processes.append(
+                        merge_images(
+                            window,
+                            file_name,
+                            None
+                        )
+                    )
+                    
+            
+        while len(processes):
+            processes.pop()[0].join()
+
+        files=new_files
+    
+    return new_files
+
+if __name__ == "__main__":
+    windowed_stiching("./source_images", 7)

--- a/set_up/image_stitching.bash
+++ b/set_up/image_stitching.bash
@@ -1,0 +1,11 @@
+git clone "https://github.com/krupkat/xpano.git"
+cd ./xpano
+sudo apt install -y libgtk-3-dev libopencv-dev libsdl2-dev libspdlog-dev cmake gcc g++ python3
+./misc/build/build-ubuntu-22.sh
+
+cd ./xpano/build
+
+export XPANO="$(pwd)/xpano"
+
+cd ..
+cd ..


### PR DESCRIPTION
 **-  Implemented a pipeline of gnu parallels in order to run all programs at the same time, it includes:**
   - [ ] QGroundControl launches correctly with the first camera preview.
   - [ ] Gstreamer commands for all the 3 cameras, including previews, snippets and logging. They still need to be run in the background to not interrupt the server & window tiling jobs.
   - [ ] Window tiling, however I couldn't fully test this functionality since im using an Xserver, so here's the hack I used: https://unix.stackexchange.com/questions/460384/open-and-tile-windows-with-shell-script
   - [ ] rov_sensor_broadcasting TCP server with simple changes (hard coded values, full directory instead of the bash build file in rov_sensor_broadcaster) just to make testing easier.
   - [ ] Missing XPano launch file